### PR TITLE
feat: Replace action calls with inlinable patterns

### DIFF
--- a/NexYaml.SourceGenerator/Templates/DeserializeEmitter.cs
+++ b/NexYaml.SourceGenerator/Templates/DeserializeEmitter.cs
@@ -31,10 +31,11 @@ internal class DeserializeEmitter
         }
         return $$"""
         {{package.CreateTempMembers()}}
-                stream.ReadMapping((key) => {
+                foreach (var key in stream.ReadMapping())
+                {
         {{ifstatement}}
 
-                });
+                }
 
                 var __TEMP__RESULT = new {{info.NameDefinition}}
                 {
@@ -85,7 +86,7 @@ internal class DeserializeEmitter
 
     private void AppendMember(SymbolInfo symbol, StringBuilder switchBuilder)
     {
-        switchBuilder.AppendLine($"\t\t\t\t!stream.TryRead(ref __TEMP__{symbol.Name}, ref key,{"UTF8" + symbol.Name}, ref __TEMP__RESULT__{symbol.Name}) &&");
+        switchBuilder.AppendLine($"\t\t\t\t!stream.TryRead(ref __TEMP__{symbol.Name}, in key, {"UTF8" + symbol.Name}, ref __TEMP__RESULT__{symbol.Name}) &&");
     }
     public string MapPropertiesToSwitch(Dictionary<int, List<SymbolInfo>> properties)
     {

--- a/NexYaml/IYamlReader.cs
+++ b/NexYaml/IYamlReader.cs
@@ -40,6 +40,6 @@ public interface IYamlReader
     bool TryGetScalarAsSpan([MaybeNullWhen(false)] out ReadOnlySpan<byte> span);
     bool TryGetScalarAsString(out string? value);
     
-    public bool TryRead<T>(ref T? target, ref ReadOnlySpan<byte> key, byte[] mappingKey, ref ParseResult parseResult);
-    public bool TryRead<T>(ref T? target, ref ReadOnlySpan<byte> key, byte[] mappingKey);
+    public bool TryRead<T>(ref T? target, in ReadOnlySpan<byte> key, byte[] mappingKey, ref ParseResult parseResult);
+    public bool TryRead<T>(ref T? target, in ReadOnlySpan<byte> key, byte[] mappingKey);
 }

--- a/NexYaml/Serializers/ArraySerializer.cs
+++ b/NexYaml/Serializers/ArraySerializer.cs
@@ -7,25 +7,23 @@ public class ArraySerializer<T> : YamlSerializer<T[]>
 {
     public override void Write(IYamlWriter stream, T[] value, DataStyle style)
     {
-        stream.WriteSequence(style, () =>
+        using (stream.SequenceScope(style))
         {
             foreach (var x in value)
             {
                 var val = x;
                 stream.Write(val, style);
             }
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref T[] value, ref ParseResult result)
     {
         var list = new List<T>();
-        stream.ReadSequence(() =>
-        {
-            var val = default(T);
-            stream.Read(ref val);
-            list.Add(val!);
-        });
+
+        foreach(var val in stream.ReadAsSequenceOf<T>())
+            list.Add(val);
+
         value = [.. list];
     }
 }

--- a/NexYaml/Serializers/CollectionInterfaceSerializer.cs
+++ b/NexYaml/Serializers/CollectionInterfaceSerializer.cs
@@ -7,25 +7,21 @@ public class CollectionInterfaceSerializer<T> : YamlSerializer<ICollection<T>?>
 {
     public override void Write(IYamlWriter stream, ICollection<T>? value, DataStyle style)
     {
-        stream.WriteSequence(style, () =>
+        using (stream.SequenceScope(style))
         {
             foreach (var x in value!)
             {
                 stream.Write(x, style);
             }
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref ICollection<T>? value, ref ParseResult result)
     {
         var list = new List<T>();
 
-        stream.ReadSequence(() =>
-        {
-            var val = default(T);
-            stream.Read(ref val);
-            list.Add(val!);
-        });
+        foreach (var val in stream.ReadAsSequenceOf<T>())
+            list.Add(val);
 
         value = list;
     }

--- a/NexYaml/Serializers/DictionaryInterfaceSerializer.cs
+++ b/NexYaml/Serializers/DictionaryInterfaceSerializer.cs
@@ -11,26 +11,26 @@ public class DictionaryInterfaceSerializer<TKey, TValue> : YamlSerializer<IDicti
     {
         if (SerializerExtensions.IsPrimitive(typeof(TKey)))
         {
-            stream.WriteMapping(style, () =>
+            using (stream.MappingScope(style))
             {
                 foreach (var x in value)
                 {
                     stream.Write(x.Key, style);
                     stream.Write(x.Value, style);
                 }
-            });
+            }
             return;
         }
         else
         {
             var kvp = new KeyValuePairSerializer<TKey, TValue>();
-            stream.WriteSequence(style, () =>
+            using (stream.SequenceScope(style))
             {
                 foreach (var x in value)
                 {
                     kvp.Write(stream, x);
                 }
-            });
+            }
         }
     }
 

--- a/NexYaml/Serializers/DictionaryReadonlyInterfaceSerializer.cs
+++ b/NexYaml/Serializers/DictionaryReadonlyInterfaceSerializer.cs
@@ -11,26 +11,26 @@ public class DictionaryReadonlyInterfaceSerializer<TKey, TValue> : YamlSerialize
     {
         if (SerializerExtensions.IsPrimitive(typeof(TKey)))
         {
-            stream.WriteMapping(style, () =>
+            using (stream.MappingScope(style))
             {
                 foreach (var x in value)
                 {
                     stream.Write(x.Key, style);
                     stream.Write(x.Value, style);
                 }
-            });
+            }
             return;
         }
         else
         {
             var kvp = new KeyValuePairSerializer<TKey, TValue>();
-            stream.WriteSequence(style, () =>
+            using (stream.SequenceScope(style))
             {
                 foreach (var x in value)
                 {
                     kvp.Write(stream, x);
                 }
-            });
+            }
         }
     }
 

--- a/NexYaml/Serializers/DictionarySerializer.cs
+++ b/NexYaml/Serializers/DictionarySerializer.cs
@@ -61,13 +61,13 @@ internal class DictionarySerializerFactory : IYamlSerializerFactory
         else
         {
             var kvp = new KeyValuePairSerializer<TKey, TValue>();
-            stream.WriteSequence(style, () =>
+            using (stream.SequenceScope(style))
             {
                 foreach (var x in value)
                 {
                     kvp.Write(stream, x);
                 }
-            });
+            }
         }
     }
 

--- a/NexYaml/Serializers/InterfaceEnumerableSerializer.cs
+++ b/NexYaml/Serializers/InterfaceEnumerableSerializer.cs
@@ -7,25 +7,22 @@ public class InterfaceEnumerableSerializer<T> : YamlSerializer<IEnumerable<T>?>
 {
     public override void Write(IYamlWriter stream, IEnumerable<T>? value, DataStyle style)
     {
-        stream.WriteSequence(style, () =>
+        using (stream.SequenceScope(style))
         {
             foreach (var x in value!)
             {
                 stream.Write(x, style);
             }
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref IEnumerable<T>? value, ref ParseResult result)
     {
         var list = new List<T>();
 
-        stream.ReadSequence(() =>
-        {
-            T? val = default;
-            stream.Read(ref val);
-            list.Add(val!);
-        });
+        foreach (var val in stream.ReadAsSequenceOf<T>())
+            list.Add(val);
+
         value = list;
     }
 }

--- a/NexYaml/Serializers/InterfaceLisSerializer.cs
+++ b/NexYaml/Serializers/InterfaceLisSerializer.cs
@@ -18,12 +18,8 @@ public class InterfaceLisSerializer<T> : YamlSerializer<IList<T>>
     public override void Read(IYamlReader stream, ref IList<T> value, ref ParseResult result)
     {
         var list = new List<T>();
-        stream.ReadSequence(() =>
-        {
-            var val = default(T);
-            stream.Read(ref val);
-            list.Add(val!);
-        });
-        value = list!;
+        foreach (var val in stream.ReadAsSequenceOf<T>())
+            list.Add(val);
+        value = list;
     }
 }

--- a/NexYaml/Serializers/InterfaceReadOnlyCollectionSerializer.cs
+++ b/NexYaml/Serializers/InterfaceReadOnlyCollectionSerializer.cs
@@ -7,24 +7,20 @@ public class InterfaceReadOnlyCollectionSerializer<T> : YamlSerializer<IReadOnly
 {
     public override void Write(IYamlWriter stream, IReadOnlyCollection<T>? value, DataStyle style)
     {
-        stream.WriteSequence(style, () =>
+        using (stream.SequenceScope(style))
         {
             foreach (var x in value)
             {
                 stream.Write(x, style);
             }
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref IReadOnlyCollection<T>? value, ref ParseResult result)
     {
         var list = new List<T>();
-        stream.ReadSequence(() =>
-        {
-            var val = default(T);
-            stream.Read(ref val);
+        foreach (var val in stream.ReadAsSequenceOf<T>())
             list.Add(val!);
-        });
-        value = list!;
+        value = list;
     }
 }

--- a/NexYaml/Serializers/InterfaceReadOnlyListSerializer.cs
+++ b/NexYaml/Serializers/InterfaceReadOnlyListSerializer.cs
@@ -7,24 +7,20 @@ public class InterfaceReadOnlyListSerializer<T> : YamlSerializer<IReadOnlyList<T
 {
     public override void Write(IYamlWriter stream, IReadOnlyList<T>? value, DataStyle style)
     {
-        stream.WriteSequence(style, () =>
+        using (stream.SequenceScope(style))
         {
             foreach (var x in value)
             {
                 stream.Write(x, style);
             }
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref IReadOnlyList<T>? value, ref ParseResult result)
     {
         var list = new List<T>();
-        stream.ReadSequence(() =>
-        {
-            var val = default(T);
-            stream.Read(ref val);
+        foreach (var val in stream.ReadAsSequenceOf<T>())
             list.Add(val!);
-        });
-        value = list!;
+        value = list;
     }
 }

--- a/NexYaml/Serializers/KeyValuePairSerializer.cs
+++ b/NexYaml/Serializers/KeyValuePairSerializer.cs
@@ -9,22 +9,22 @@ public class KeyValuePairSerializer<TKey, TValue> : YamlSerializer<KeyValuePair<
     public override void Write(IYamlWriter stream, KeyValuePair<TKey, TValue> value, DataStyle style)
     {
         var x = value.Key;
-        stream.WriteSequence(style, () =>
+        using (stream.SequenceScope(style))
         {
             stream.Write(value.Key, style);
             stream.Write(value.Value, style);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref KeyValuePair<TKey, TValue> value, ref ParseResult result)
     {
         var key = default(TKey);
         var val = default(TValue);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref key);
             stream.Read(ref val);
-        });
+        }
         value = new KeyValuePair<TKey, TValue>(key!, val!);
     }
 }

--- a/NexYaml/Serializers/TupleSerializer.cs
+++ b/NexYaml/Serializers/TupleSerializer.cs
@@ -7,20 +7,18 @@ public class TupleSerializer<T1> : YamlSerializer<Tuple<T1>?>
 {
     public override void Write(IYamlWriter stream, Tuple<T1>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1>? value, ref ParseResult result)
     {
-        var item1 = default(T1);
-        stream.ReadSequence(() =>
+        foreach (var val in stream.ReadAsSequenceOf<T1>())
         {
-            stream.Read(ref item1);
-        });
-        value = new Tuple<T1>(item1!);
+            value = new Tuple<T1>(val); 
+        }
     }
 }
 
@@ -28,22 +26,22 @@ public class TupleSerializer<T1, T2> : YamlSerializer<Tuple<T1, T2>?>
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2>? value, ref ParseResult result)
     {
         var item1 = default(T1);
         var item2 = default(T2);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
-        });
+        }
         value = new Tuple<T1, T2>(item1!, item2!);
     }
 }
@@ -52,12 +50,12 @@ public class TupleSerializer<T1, T2, T3> : YamlSerializer<Tuple<T1, T2, T3>?>
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2, T3>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
             stream.Write(value.Item3, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2, T3>? value, ref ParseResult result)
@@ -65,12 +63,12 @@ public class TupleSerializer<T1, T2, T3> : YamlSerializer<Tuple<T1, T2, T3>?>
         var item1 = default(T1);
         var item2 = default(T2);
         var item3 = default(T3);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
             stream.Read(ref item3);
-        });
+        }
         value = new Tuple<T1, T2, T3>(item1, item2, item3);
     }
 }
@@ -79,13 +77,13 @@ public class TupleSerializer<T1, T2, T3, T4> : YamlSerializer<Tuple<T1, T2, T3, 
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2, T3, T4>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
             stream.Write(value.Item3, DataStyle.Compact);
             stream.Write(value.Item4, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2, T3, T4>? value, ref ParseResult result)
@@ -94,13 +92,13 @@ public class TupleSerializer<T1, T2, T3, T4> : YamlSerializer<Tuple<T1, T2, T3, 
         var item2 = default(T2);
         var item3 = default(T3);
         var item4 = default(T4);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
             stream.Read(ref item3);
             stream.Read(ref item4);
-        });
+        }
         value = new Tuple<T1, T2, T3, T4>(item1, item2, item3, item4);
     }
 }
@@ -109,14 +107,14 @@ public class TupleSerializer<T1, T2, T3, T4, T5> : YamlSerializer<Tuple<T1, T2, 
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2, T3, T4, T5>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
             stream.Write(value.Item3, DataStyle.Compact);
             stream.Write(value.Item4, DataStyle.Compact);
             stream.Write(value.Item5, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2, T3, T4, T5>? value, ref ParseResult result)
@@ -126,14 +124,14 @@ public class TupleSerializer<T1, T2, T3, T4, T5> : YamlSerializer<Tuple<T1, T2, 
         var item3 = default(T3);
         var item4 = default(T4);
         var item5 = default(T5);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
             stream.Read(ref item3);
             stream.Read(ref item4);
             stream.Read(ref item5);
-        });
+        }
         value = new Tuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
     }
 }
@@ -142,7 +140,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Tuple<T1, 
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2, T3, T4, T5, T6>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
@@ -150,7 +148,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Tuple<T1, 
             stream.Write(value.Item4, DataStyle.Compact);
             stream.Write(value.Item5, DataStyle.Compact);
             stream.Write(value.Item6, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2, T3, T4, T5, T6>? value, ref ParseResult result)
@@ -161,7 +159,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Tuple<T1, 
         var item4 = default(T4);
         var item5 = default(T5);
         var item6 = default(T6);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
@@ -169,7 +167,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Tuple<T1, 
             stream.Read(ref item4);
             stream.Read(ref item5);
             stream.Read(ref item6);
-        });
+        }
         value = new Tuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
     }
 }
@@ -178,7 +176,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<Tuple<
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2, T3, T4, T5, T6, T7>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
@@ -187,7 +185,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<Tuple<
             stream.Write(value.Item5, DataStyle.Compact);
             stream.Write(value.Item6, DataStyle.Compact);
             stream.Write(value.Item7, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2, T3, T4, T5, T6, T7>? value, ref ParseResult result)
@@ -199,7 +197,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<Tuple<
         var item5 = default(T5);
         var item6 = default(T6);
         var item7 = default(T7);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
@@ -208,7 +206,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<Tuple<
             stream.Read(ref item5);
             stream.Read(ref item6);
             stream.Read(ref item7);
-        });
+        }
         value = new Tuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
     }
 }
@@ -218,7 +216,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7, T8> : YamlSerializer<Tu
 {
     public override void Write(IYamlWriter stream, Tuple<T1, T2, T3, T4, T5, T6, T7, T8>? value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value!.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
@@ -228,7 +226,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7, T8> : YamlSerializer<Tu
             stream.Write(value.Item6, DataStyle.Compact);
             stream.Write(value.Item7, DataStyle.Compact);
             stream.Write(value.Rest, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref Tuple<T1, T2, T3, T4, T5, T6, T7, T8>? value, ref ParseResult result)
@@ -241,7 +239,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7, T8> : YamlSerializer<Tu
         var item6 = default(T6);
         var item7 = default(T7);
         var item8 = default(T8);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
@@ -251,7 +249,7 @@ public class TupleSerializer<T1, T2, T3, T4, T5, T6, T7, T8> : YamlSerializer<Tu
             stream.Read(ref item6);
             stream.Read(ref item7);
             stream.Read(ref item8);
-        });
+        }
         value = new Tuple<T1, T2, T3, T4, T5, T6, T7, T8>(item1, item2, item3, item4, item5, item6, item7, item8);
     }
 }

--- a/NexYaml/Serializers/ValueTupleSerializer.cs
+++ b/NexYaml/Serializers/ValueTupleSerializer.cs
@@ -7,19 +7,19 @@ public class ValueTupleSerializer<T1> : YamlSerializer<ValueTuple<T1>>
 {
     public override void Write(IYamlWriter stream, ValueTuple<T1> value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref ValueTuple<T1> value, ref ParseResult result)
     {
         var item1 = default(T1);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
-        });
+        }
         value = new ValueTuple<T1>(item1);
     }
 }
@@ -28,22 +28,22 @@ public class ValueTupleSerializer<T1, T2> : YamlSerializer<ValueTuple<T1, T2>>
 {
     public override void Write(IYamlWriter stream, (T1, T2) value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref (T1, T2) value, ref ParseResult result)
     {
         var item1 = default(T1);
         var item2 = default(T2);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
-        });
+        }
         value = new ValueTuple<T1, T2>(item1, item2);
     }
 }
@@ -52,12 +52,12 @@ public class ValueTupleSerializer<T1, T2, T3> : YamlSerializer<ValueTuple<T1, T2
 {
     public override void Write(IYamlWriter stream, (T1, T2, T3) value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
             stream.Write(value.Item3, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref (T1, T2, T3) value, ref ParseResult result)
@@ -65,12 +65,12 @@ public class ValueTupleSerializer<T1, T2, T3> : YamlSerializer<ValueTuple<T1, T2
         var item1 = default(T1);
         var item2 = default(T2);
         var item3 = default(T3);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
             stream.Read(ref item3);
-        });
+        }
         value = new ValueTuple<T1, T2, T3>(item1, item2, item3);
     }
 }
@@ -79,13 +79,13 @@ public class ValueTupleSerializer<T1, T2, T3, T4> : YamlSerializer<ValueTuple<T1
 {
     public override void Write(IYamlWriter stream, (T1, T2, T3, T4) value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
             stream.Write(value.Item3, DataStyle.Compact);
             stream.Write(value.Item4, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref (T1, T2, T3, T4) value, ref ParseResult result)
@@ -94,13 +94,13 @@ public class ValueTupleSerializer<T1, T2, T3, T4> : YamlSerializer<ValueTuple<T1
         var item2 = default(T2);
         var item3 = default(T3);
         var item4 = default(T4);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
             stream.Read(ref item3);
             stream.Read(ref item4);
-        });
+        }
         value = new ValueTuple<T1, T2, T3, T4>(item1, item2, item3, item4);
     }
 }
@@ -109,14 +109,14 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5> : YamlSerializer<ValueTupl
 {
     public override void Write(IYamlWriter stream, (T1, T2, T3, T4, T5) value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
             stream.Write(value.Item3, DataStyle.Compact);
             stream.Write(value.Item4, DataStyle.Compact);
             stream.Write(value.Item5, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref (T1, T2, T3, T4, T5) value, ref ParseResult result)
@@ -126,14 +126,14 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5> : YamlSerializer<ValueTupl
         var item3 = default(T3);
         var item4 = default(T4);
         var item5 = default(T5);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
             stream.Read(ref item3);
             stream.Read(ref item4);
             stream.Read(ref item5);
-        });
+        }
         value = new ValueTuple<T1, T2, T3, T4, T5>(item1, item2, item3, item4, item5);
     }
 }
@@ -142,7 +142,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Value
 {
     public override void Write(IYamlWriter stream, (T1, T2, T3, T4, T5, T6) value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
@@ -150,7 +150,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Value
             stream.Write(value.Item4, DataStyle.Compact);
             stream.Write(value.Item5, DataStyle.Compact);
             stream.Write(value.Item6, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref (T1, T2, T3, T4, T5, T6) value, ref ParseResult result)
@@ -161,7 +161,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Value
         var item4 = default(T4);
         var item5 = default(T5);
         var item6 = default(T6);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
@@ -169,7 +169,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6> : YamlSerializer<Value
             stream.Read(ref item4);
             stream.Read(ref item5);
             stream.Read(ref item6);
-        });
+        }
         value = new ValueTuple<T1, T2, T3, T4, T5, T6>(item1, item2, item3, item4, item5, item6);
     }
 }
@@ -178,7 +178,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<V
 {
     public override void Write(IYamlWriter stream, (T1, T2, T3, T4, T5, T6, T7) value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
@@ -187,7 +187,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<V
             stream.Write(value.Item5, DataStyle.Compact);
             stream.Write(value.Item6, DataStyle.Compact);
             stream.Write(value.Item7, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref (T1, T2, T3, T4, T5, T6, T7) value, ref ParseResult result)
@@ -199,7 +199,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<V
         var item5 = default(T5);
         var item6 = default(T6);
         var item7 = default(T7);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
@@ -208,7 +208,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7> : YamlSerializer<V
             stream.Read(ref item5);
             stream.Read(ref item6);
             stream.Read(ref item7);
-        });
+        }
         value = new ValueTuple<T1, T2, T3, T4, T5, T6, T7>(item1, item2, item3, item4, item5, item6, item7);
     }
 }
@@ -218,7 +218,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7, TRest> : YamlSeria
 {
     public override void Write(IYamlWriter stream, ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, DataStyle style)
     {
-        stream.WriteSequence(DataStyle.Compact, () =>
+        using (stream.SequenceScope(DataStyle.Compact))
         {
             stream.Write(value.Item1, DataStyle.Compact);
             stream.Write(value.Item2, DataStyle.Compact);
@@ -228,7 +228,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7, TRest> : YamlSeria
             stream.Write(value.Item6, DataStyle.Compact);
             stream.Write(value.Item7, DataStyle.Compact);
             stream.Write(value.Rest, DataStyle.Compact);
-        });
+        }
     }
 
     public override void Read(IYamlReader stream, ref ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest> value, ref ParseResult result)
@@ -241,7 +241,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7, TRest> : YamlSeria
         var item6 = default(T6);
         var item7 = default(T7);
         var item8 = default(TRest);
-        stream.ReadSequence(() =>
+        using (stream.SequenceScope())
         {
             stream.Read(ref item1);
             stream.Read(ref item2);
@@ -251,7 +251,7 @@ public class ValueTupleSerializer<T1, T2, T3, T4, T5, T6, T7, TRest> : YamlSeria
             stream.Read(ref item6);
             stream.Read(ref item7);
             stream.Read(ref item8);
-        });
+        }
         value = new ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>(item1, item2, item3, item4, item5, item6, item7, item8);
     }
 }

--- a/NexYaml/YamlReader.cs
+++ b/NexYaml/YamlReader.cs
@@ -171,7 +171,7 @@ public class YamlReader(YamlParser parser, IYamlSerializerResolver Resolver) : I
     {
         parser.Reset();
     }
-    public bool TryRead<T>(ref T? target, ref ReadOnlySpan<byte> key, byte[] mappingKey, ref ParseResult parseResult)
+    public bool TryRead<T>(ref T? target, in ReadOnlySpan<byte> key, byte[] mappingKey, ref ParseResult parseResult)
     {
         if (key.SequenceEqual(mappingKey))
         {
@@ -182,7 +182,7 @@ public class YamlReader(YamlParser parser, IYamlSerializerResolver Resolver) : I
         return false;
     }
 
-    public bool TryRead<T>(ref T? target, ref ReadOnlySpan<byte> key, byte[] mappingKey)
+    public bool TryRead<T>(ref T? target, in ReadOnlySpan<byte> key, byte[] mappingKey)
     {
         var parseResult = new ParseResult();
         if (key.SequenceEqual(mappingKey))

--- a/NexYaml/YamlWriterExtensions.cs
+++ b/NexYaml/YamlWriterExtensions.cs
@@ -6,30 +6,34 @@ namespace NexYaml;
 
 public static class YamlWriterExtensions
 {
-    /// <summary>
-    /// Run the <paramref name="action"/> on the stream while wrapping it into <see cref="IYamlWriter.BeginMapping(DataStyle)"
-    /// </summary>
-    /// <param name="stream">The <see cref="IYamlWriter"/> to write to</param>
-    /// <param name="style">The <see cref="DataStyle"/> to format the mapping</param>
-    /// <param name="action">The Action to run inside the mapping</param>
-    public static void WriteMapping(this IYamlWriter stream, DataStyle style, Action action)
+    public static MappingScopeDisposable MappingScope(this IYamlWriter stream, DataStyle style) => new(stream, style);
+    
+    public static SequenceScopeDisposable SequenceScope(this IYamlWriter stream, DataStyle style) => new(stream, style);
+
+    public struct SequenceScopeDisposable : IDisposable
     {
-        stream.BeginMapping(style);
-        action();
-        stream.EndMapping();
+        private IYamlWriter _stream;
+        
+        public SequenceScopeDisposable(IYamlWriter stream, DataStyle style)
+        {
+            _stream = stream;
+            _stream.BeginSequence(style);
+        }
+
+        public void Dispose() => _stream.EndSequence();
     }
 
-    /// <summary>
-    /// Run the <paramref name="action"/> on the stream while wrapping it into <see cref="IYamlWriter.BeginSequence(DataStyle)"
-    /// </summary>
-    /// <param name="stream">The <see cref="IYamlWriter"/> to write to</param>
-    /// <param name="style">The <see cref="DataStyle"/> to format the mapping</param>
-    /// <param name="action">The Action to run inside the mapping</param>
-    public static void WriteSequence(this IYamlWriter stream, DataStyle style, Action action)
+    public struct MappingScopeDisposable : IDisposable
     {
-        stream.BeginSequence(style);
-        action();
-        stream.EndSequence();
+        private IYamlWriter _stream;
+        
+        public MappingScopeDisposable(IYamlWriter stream, DataStyle style)
+        {
+            _stream = stream;
+            _stream.BeginMapping(style);
+        }
+
+        public void Dispose() => _stream.EndMapping();
     }
 
     /// <summary>


### PR DESCRIPTION
Passing actions as argument is extremely unlikely to be inlined, meaning a bunch of avoidable virtual calls and allocations.
Let me know what you think.

Also, note that I couldn't actually build and run the project in debug out of the box; `Could not find a part of the path 'I:\NexYamlSerializer\NexYaml.SourceGenerator\bin\Release\netstandard2.0'` which likely relates to your https://github.com/NexStandard/NexYamlSerializer/blob/60cc8eeb08c5a766a90bf45a4889fc7b90f9603d/NexYaml/NexYaml.csproj#L22
And the console app expects the file to exist, I think you should use an open or create flag instead and dump it at the root of the program instead of a random disk that may not exist.